### PR TITLE
Fix string comparison to use [[ ]] since bashisms are in use anyway.

### DIFF
--- a/xpacks-paths.sh
+++ b/xpacks-paths.sh
@@ -4,15 +4,15 @@
 # Prefer the environment locations XPACKS_REPO_FOLDER/XPACKS_CACHE_FOLDER, 
 # if defined, otherwise default to platform specific locations.
 host_uname="$(uname)"
-if [ "${host_uname}" == "Darwin" ]
+if [[ "${host_uname}" == "Darwin" ]]
 then
   xpacks_repo_folder_path="${XPACKS_REPO_FOLDER:-$HOME/Library/xPacks}"
   xpacks_cache_folder_path="${XPACKS_CACHE_FOLDER:-$HOME/Library/Caches/xPacks}"
-elif [ "${host_uname}" == "Linux" ]
+elif [[ "${host_uname}" == "Linux" ]]
 then
   xpacks_repo_folder_path="${XPACKS_REPO_FOLDER:-$HOME/.xpacks}"
   xpacks_cache_folder_path="${XPACKS_CACHE_FOLDER:-$HOME/.cache/xpacks}"
-elif [ "${host_uname:0:6}" == "MINGW64" ]
+elif [[ "${host_uname:0:6}" == "MINGW64" ]]
 then
   xpacks_repo_folder_path="${XPACKS_REPO_FOLDER:-$HOME/AppData/Roaming/xPacks}"
   xpacks_cache_folder_path="${XPACKS_CACHE_FOLDER:-$HOME/AppData/Local/Caches/xPacks}"


### PR DESCRIPTION
The `==` for string equality checking, I believe, is bash syntax - in any case, with the normal `sh` single-`[]` syntax, I got:

```
$ ./xpacks-paths.sh
MINGW64_NT-10.0 not supported
```

on "git bash" when there's clearly a case intended to handle it. Switching to the bash `[[ ]]` syntax seemed to fix at least that part.