### PR TITLE
Correctly extract substring of uname to recognize MINGW64

### DIFF
--- a/xpacks-paths.sh
+++ b/xpacks-paths.sh
@@ -12,7 +12,7 @@ elif [ "${host_uname}" == "Linux" ]
 then
   xpacks_repo_folder_path="${XPACKS_REPO_FOLDER:-$HOME/.xpacks}"
   xpacks_cache_folder_path="${XPACKS_CACHE_FOLDER:-$HOME/.cache/xpacks}"
-elif [ "${host_uname:0:6}" == "MINGW64" ]
+elif [ "${host_uname:0:7}" == "MINGW64" ]
 then
   xpacks_repo_folder_path="${XPACKS_REPO_FOLDER:-$HOME/AppData/Roaming/xPacks}"
   xpacks_cache_folder_path="${XPACKS_CACHE_FOLDER:-$HOME/AppData/Local/Caches/xPacks}"


### PR DESCRIPTION
Fixes out-of-box experience on Windows when using, e.g., git bash.

Before patch, running `generate.sh` from a sample project:

```
$ ./generate.sh
MINGW64_NT-10.0 not supported
```

After:

````
$ ./generate.sh
Downloading bootstrap.sh...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   134  100   134    0     0    238      0 --:--:-- --:--:-- --:--:--   252
100  1218  100  1218    0     0   1559      0 --:--:-- --:--:-- --:--:--  1559
Creating /c/Users/Ryan/AppData/Roaming/xPacks
```

etc. (until it hits the hard link error)